### PR TITLE
fix: local stack memory assigned to global

### DIFF
--- a/NVP_Parser.cpp
+++ b/NVP_Parser.cpp
@@ -1,8 +1,8 @@
 #include "Arduino.h"
 #include "NVP_Parser.h"
 
-char* RFQ;
-char* RPW;
+char[MAX_KV_LEN] RFQ;
+char[MAX_KV_LEN] RPW;
 
 void fclass::NVPparser(String NVP_Input) {
 
@@ -38,8 +38,12 @@ void fclass::NVPparser(String NVP_Input) {
   for (int i = 0; i < kv_count; i++) {
     //printf("Key: %s, Value: %s\n", pairs[i].key, pairs[i].value);
 
-    if (!strcmp(pairs[i].key, "RFQ")) { RFQ = pairs[i].value; }
-    if (!strcmp(pairs[i].key, "RPW")) { RPW = pairs[i].value; }
+    if (!strcmp(pairs[i].key, "RFQ")) {
+      strncpy(RFQ, pairs[i].value, MAX_KV_LEN);
+    }
+    if (!strcmp(pairs[i].key, "RPW")) {
+      strncpy(RPW, pairs[i].value, MAX_KV_LEN);
+    }
   }
 
   // String myString = String(pairs[1].value);

--- a/NVP_Parser.cpp
+++ b/NVP_Parser.cpp
@@ -1,8 +1,8 @@
 #include "Arduino.h"
 #include "NVP_Parser.h"
 
-char[MAX_KV_LEN] RFQ;
-char[MAX_KV_LEN] RPW;
+char RFQ[MAX_KV_LEN];
+char RPW[MAX_KV_LEN];
 
 void fclass::NVPparser(String NVP_Input) {
 

--- a/NVP_Parser.h
+++ b/NVP_Parser.h
@@ -40,7 +40,7 @@ public:
 extern fclass NVP;
 
 //Global NVP variables
-extern char *RFQ;  // rain frequency
-extern char *RPW;  // rain pulse width
+extern char RFQ[MAX_KV_LEN];  // rain frequency
+extern char RPW[MAX_KV_LEN];  // rain pulse width
 
 #endif


### PR DESCRIPTION
RFQ and RPW were being assigned memory addresses of elements of the pairs struct which uses local stack memory storage. Once the function scope ends, the pairs memory is no longer valid and RFQ/RPW still point to that memory.

To fix this, I've made the RFQ and RPW strings statically sized, so they'll have static global memory. This does means we can't simply assign the pointers, and instead need to do a strcpy.

If you would like a more general fix, such that any key can be extracted to a global, you could make the pairs struct a static member of the class, so then it has static memory lifetime, and the RFQ, RPW et al pointers will point to valid memory. Keep in mind that this will use an additional `MAX_PAIRS * MAX_KV_LEN * 2` memory, versus that for just the extracted values you need. For an embedded device, I'd say memory is a more critical resource, which is why the proposed solution was chosen.

## Testing

I haven't actually loaded this up on a device, but I think the culprit is fairly clear here. Dereferencing invalid stack memory would certainly cause a kernel panic.

I did however test the code in Visual Studio (just had to replace Arduino types where relevant) with the following main code:

```c++
int main()
{
	NVP.NVPparser("var1=red|var2=green|var3=up|var4=down|RPW=50|RFQ=100|time=123443291|key=left");

	std::cout << "RFQ: " << RFQ << "\n";
	std::cout << "RPW: " << RPW << "\n";
}
```

output:
```
RFQ:100
RPW:50
```

I can also see stepping through the code that the parsing algorithm works generally too, i.e. `var1`, `var2` etc. are all split out into the pairs struct too.